### PR TITLE
Adding support for build options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - adding more build options to build as build-flags (0.0.13)
  - when not using sudo, need to set --network=none, and catching exec error (0.0.12)
  - pyaml version should be for newer kind, and still check for attribute (0.0.11)
  - alpha release with simple (single container) working example (0.0.1)

--- a/docs/spec/spec-1.0.md
+++ b/docs/spec/spec-1.0.md
@@ -111,6 +111,7 @@ field (not defined above).|
 |build| a section to define how and where to build the base container from.|
 |build.context| the folder with the Singularity file (and other relevant files). Must exist.
 |build.recipe| the Singularity recipe in the build context folder. It defaults to `Singularity`|
+|build.options| a list of one or more options (single strings for boolean, or key value pairs for arguments) to provide to build. |
 |image| is looked for after a build entry. It can be a unique resource identifier, or container binary. |
 |volumes| one or more files or files to bind to the instance when it's started.|
 |volumes_from| shared volumes that are defined for other instances|

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.12"
+__version__ = "0.0.13"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'singularity-compose'

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -31,7 +31,7 @@ LICENSE = "LICENSE"
 
 
 INSTALL_REQUIRES = (
-    ('spython', {'min_version': '0.0.67'}),
+    ('spython', {'min_version': '0.0.68'}),
     ('pyaml', {'min_version': '5.1.1'}),
 )
 


### PR DESCRIPTION
Any boolean (flag) or build argument that Singularity can accept can now be provided in the singularity-compose.yml

```
version: "1.0"
instances:

  mongodb:
    build:
      context: ./mongodb
      options:
        - fakeroot
    volumes:
      - ./mongodb/data:/data
    post:
      command: ["/bin/bash", "./mongodb/run_post.sh"]
```
This gives a user flexibility to build without root (fakeroot or remote) along with any other options supported by Singularity build. This will close #14 