### PR TITLE
Disable non-sudo networking - closes #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - custom networking disabled for non-sudo users
+ - resolv.conf and etc.hosts generated just if needed
  - resolv.conf needs to bind by default (0.0.16)
  - adding run command (0.0.15)
  - ensuring that builds are streamed (0.0.14)

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -489,21 +489,24 @@ class Instance(object):
 
             bot.info("Creating %s" % self.name)
 
+            # Command options
+            options = []
+
             # Volumes
-            binds = self._get_bind_commands()
+            options += self._get_bind_commands()
 
-            # Ports
-            ports = self._get_network_commands(ip_address)
+            if sudo:
+                # Ports
+                options += self._get_network_commands(ip_address)
 
-            # Hostname
-            hostname = ["--hostname", self.name]
+                # Hostname
+                options += ["--hostname", self.name]
 
             # Writable Temporary Directory
             if writable_tmpfs:
-                hostname += ['--writable-tmpfs']
+                options += ['--writable-tmpfs']
 
             # Show the command to the user
-            options = binds + ports + hostname
             commands = "%s %s %s" % (' '.join(options), image, self.name)
             bot.debug('singularity instance start %s' % commands)
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -437,8 +437,9 @@ class Project(object):
         # Generate ip addresses for each
         lookup = self.get_ip_lookup(names, bridge)
 
-        # Generate shared hosts file
-        hosts_file = self.create_hosts(lookup)
+        if self.sudo and not no_resolv:
+            # Generate shared hosts file
+            hosts_file = self.create_hosts(lookup)
 
         # First create those with no dependencies
         while names:
@@ -458,12 +459,12 @@ class Project(object):
                 if do_create:
 
                     # Generate a resolv.conf to bind to the container
-                    if not no_resolv:
+                    if self.sudo and not no_resolv:
                         resolv = self.generate_resolv_conf()
                         instance.volumes.append('%s:/etc/resolv.conf' % resolv)
 
-                    # Create a hosts file for the instance based, add as volume
-                    instance.volumes.append('%s:/etc/hosts' % hosts_file)
+                        # Create a hosts file for the instance based, add as volume
+                        instance.volumes.append('%s:/etc/hosts' % hosts_file)
 
                     # If we get here, execute command and add to list
                     create_func = getattr(instance, command)

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -17,7 +17,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 '''
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 AUTHOR = 'Vanessa Sochat'
 AUTHOR_EMAIL = 'vsochat@stanford.edu'
 NAME = 'singularity-compose'


### PR DESCRIPTION
Implemented features:

- When the user is not sudo or doesn't want to use a custom resolv.conf, don't generate `hosts` and `resolv` files
- When the user is not sudo, don't use bridged networking (because it would not work)
