### PR TITLE
Adding test for depends_on

### DIFF
--- a/.docs/changelog.md
+++ b/.docs/changelog.md
@@ -1,1 +1,26 @@
-../CHANGELOG.md
+# CHANGELOG
+
+This is a manually generated log to track changes to the repository for each release. 
+Each section should include general headers such as **Implemented enhancements** 
+and **Merged pull requests**. Critical items to know are:
+
+ - renamed commands
+ - deprecated / removed commands
+ - changed defaults
+ - backward incompatible changes
+ - migration guidance
+ - changed behaviour
+
+The versions coincide with releases on pypi.
+
+## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - Improve depends\_on for circular dependencies detection and ordered shutdown (0.0.18)
+ - resolv.conf, etc.hosts generated if needed, network disabled non-sudo users (0.0.17)
+ - resolv.conf needs to bind by default (0.0.16)
+ - adding run command (0.0.15)
+ - ensuring that builds are streamed (0.0.14)
+ - adding more build options to build as build-flags (0.0.13)
+ - when not using sudo, need to set --network=none, and catching exec error (0.0.12)
+ - pyaml version should be for newer kind, and still check for attribute (0.0.11)
+ - alpha release with simple (single container) working example (0.0.1)
+ - dummy release (0.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - depends\_on, check circular dependencies at startup and shutdown in reverse order (0.0.18)
  - resolv.conf, etc.hosts generated if needed, network disabled non-sudo users (0.0.17)
  - resolv.conf needs to bind by default (0.0.16)
  - adding run command (0.0.15)

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -367,9 +367,9 @@ class Project(object):
            bring down all instances.
         """
         if not names:
-          names = list(self.get_instance_names())
-          # Ordered shutdown in case of depends_on
-          names.reverse()
+            names = list(self.get_instance_names())
+            # Ordered shutdown in case of depends_on
+            names.reverse()
 
         for instance in self.iter_instances(names):
             instance.stop()
@@ -462,10 +462,7 @@ class Project(object):
             instance.run_post()
 
         if circular_dep:
-            bot.exit(
-                "Unable to create all instances, possible circular dependency."
-            )
-
+            bot.exit("Unable to create all instances, possible circular dependency.")
 
     # Build
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -179,9 +179,9 @@ class Project(object):
                     sorted_instances.append(instance)
                     index = sorted_instances.index(instance)
 
-                for parent in depends_on:
-                    if not parent in sorted_instances:
-                        sorted_instances.insert(index, parent) # self.instances[parent]
+                for dep in depends_on:
+                    if not dep in sorted_instances:
+                        sorted_instances.insert(index, dep)
 
             self.instances = {k: self.instances[k] for k in sorted_instances}
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -190,7 +190,6 @@ class Project(object):
 
         return {k: self.instances[k] for k in sorted_instances}
 
-
     # Networking
 
     def get_ip_lookup(self, names, bridge="10.22.0.0/16"):

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -166,26 +166,30 @@ class Project(object):
                     working_dir=self.working_dir,
                 )
 
-            # Eventually reorder instances based on depends_on constraints
-            sorted_instances = []
-            for instance in self.instances:
-                depends_on = self.instances[instance].params.get("depends_on", [])
-
-                try:
-                    index = sorted_instances.index(instance)
-                except ValueError:
-                    sorted_instances.append(instance)
-                    index = sorted_instances.index(instance)
-
-                for dep in depends_on:
-                    if not dep in sorted_instances:
-                        sorted_instances.insert(index, dep)
-
-            self.instances = {k: self.instances[k] for k in sorted_instances}
+            self.instances = self._sort_instances(self.instances)
 
             # Update volumes with volumes from
             for _, instance in self.instances.items():
                 instance.set_volumes_from(self.instances)
+
+    def _sort_instances(self, instances):
+        """eventually reorder instances based on depends_on constraints"""
+        sorted_instances = []
+        for instance in self.instances:
+            depends_on = self.instances[instance].params.get("depends_on", [])
+
+            try:
+                index = sorted_instances.index(instance)
+            except ValueError:
+                sorted_instances.append(instance)
+                index = sorted_instances.index(instance)
+
+            for dep in depends_on:
+                if not dep in sorted_instances:
+                    sorted_instances.insert(index, dep)
+
+        return {k: self.instances[k] for k in sorted_instances}
+
 
     # Networking
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -51,9 +51,7 @@ class Project(object):
         """
         names = []
         if self.instances is not None:
-            names = self.instances.keys()
-        elif self.config is not None and "instances" in self.config:
-            names = list(self.config["instances"].keys())
+            names = list(self.instances.keys())
 
         return names
 
@@ -367,7 +365,7 @@ class Project(object):
            bring down all instances.
         """
         if not names:
-            names = list(self.get_instance_names())
+            names = self.get_instance_names()
             # Ordered shutdown in case of depends_on
             names.reverse()
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -50,9 +50,11 @@ class Project(object):
            are defined.
         """
         names = []
-        if self.config is not None:
-            if "instances" in self.config:
-                names = list(self.config["instances"].keys())
+        if self.instances is not None:
+            names = self.instances.keys()
+        elif self.config is not None and "instances" in self.config:
+            names = list(self.config["instances"].keys())
+
         return names
 
     def set_filename(self, filename):
@@ -165,6 +167,23 @@ class Project(object):
                     sudo=self.sudo,
                     working_dir=self.working_dir,
                 )
+
+            # Eventually reorder instances based on depends_on constraints
+            sorted_instances = []
+            for instance in self.instances:
+                depends_on = self.instances[instance].params.get("depends_on", [])
+
+                try:
+                    index = sorted_instances.index(instance)
+                except ValueError:
+                    sorted_instances.append(instance)
+                    index = sorted_instances.index(instance)
+
+                for parent in depends_on:
+                    if not parent in sorted_instances:
+                        sorted_instances.insert(index, parent) # self.instances[parent]
+
+            self.instances = {k: self.instances[k] for k in sorted_instances}
 
             # Update volumes with volumes from
             for _, instance in self.instances.items():
@@ -347,7 +366,11 @@ class Project(object):
            names: a list of names of instances to bring down. If not specified, we
            bring down all instances.
         """
-        names = names or self.get_instance_names()
+        if not names:
+          names = list(self.get_instance_names())
+          # Ordered shutdown in case of depends_on
+          names.reverse()
+
         for instance in self.iter_instances(names):
             instance.stop()
 
@@ -400,9 +423,9 @@ class Project(object):
         # If no names provided, we create all
         names = names or self.get_instance_names()
 
-        # Keep a count to determine if we have circular dependency structure
+        # Keep track of created instances to determine if we have circular dependency structure
         created = []
-        count = 0
+        circular_dep = False
 
         # Generate ip addresses for each
         lookup = self.get_ip_lookup(names, bridge)
@@ -411,50 +434,38 @@ class Project(object):
             # Generate shared hosts file
             hosts_file = self.create_hosts(lookup)
 
-        # First create those with no dependencies
-        while names:
+        for instance in self.iter_instances(names):
+            depends_on = instance.params.get("depends_on", [])
+            for dep in depends_on:
+                if dep not in created:
+                    circular_dep = True
 
-            for instance in self.iter_instances(names):
+            # Generate a resolv.conf to bind to the container
+            if self.sudo and not no_resolv:
+                resolv = self.generate_resolv_conf()
+                instance.volumes.append("%s:/etc/resolv.conf" % resolv)
 
-                # Flag to indicated create
-                do_create = True
+                # Create a hosts file for the instance based, add as volume
+                instance.volumes.append("%s:/etc/hosts" % hosts_file)
 
-                # Ensure created, skip over if not
-                depends_on = instance.params.get("depends_on", [])
-                for depends_on in depends_on:
-                    if depends_on not in created:
-                        count += 1
-                        do_create = False
+            # If we get here, execute command and add to list
+            create_func = getattr(instance, command)
+            create_func(
+                working_dir=self.working_dir,
+                writable_tmpfs=writable_tmpfs,
+                ip_address=lookup[instance.name],
+            )
 
-                if do_create:
+            created.append(instance.name)
 
-                    # Generate a resolv.conf to bind to the container
-                    if self.sudo and not no_resolv:
-                        resolv = self.generate_resolv_conf()
-                        instance.volumes.append("%s:/etc/resolv.conf" % resolv)
+            # Run post create commands
+            instance.run_post()
 
-                        # Create a hosts file for the instance based, add as volume
-                        instance.volumes.append("%s:/etc/hosts" % hosts_file)
+        if circular_dep:
+            bot.exit(
+                "Unable to create all instances, possible circular dependency."
+            )
 
-                    # If we get here, execute command and add to list
-                    create_func = getattr(instance, command)
-                    create_func(
-                        working_dir=self.working_dir,
-                        writable_tmpfs=writable_tmpfs,
-                        ip_address=lookup[instance.name],
-                    )
-
-                    created.append(instance.name)
-                    names.remove(instance.name)
-
-                    # Run post create commands
-                    instance.run_post()
-
-                # Possibly circular dependencies
-                if count >= 100:
-                    bot.exit(
-                        "Unable to create all instances, possible circular dependency."
-                    )
 
     # Build
 

--- a/scompose/tests/configs/depends_on/Singularity.first
+++ b/scompose/tests/configs/depends_on/Singularity.first
@@ -1,0 +1,6 @@
+Bootstrap: docker
+From: busybox
+
+%startscript
+printf "Present working directory is $PWD"
+printf "This is first"

--- a/scompose/tests/configs/depends_on/Singularity.second
+++ b/scompose/tests/configs/depends_on/Singularity.second
@@ -1,0 +1,6 @@
+Bootstrap: docker
+From: busybox
+
+%startscript
+printf "Present working directory is $PWD"
+printf "This is second"

--- a/scompose/tests/configs/depends_on/Singularity.third
+++ b/scompose/tests/configs/depends_on/Singularity.third
@@ -1,0 +1,6 @@
+Bootstrap: docker
+From: busybox
+
+%startscript
+printf "Present working directory is $PWD"
+printf "This is third"

--- a/scompose/tests/configs/depends_on/singularity-compose.yml
+++ b/scompose/tests/configs/depends_on/singularity-compose.yml
@@ -1,0 +1,17 @@
+version: "1.0"
+instances:
+  first:
+    build:
+      context: .
+      recipe: Singularity.first
+    depends_on: [second]
+  second:
+    build:
+      context: .
+      recipe: Singularity.second
+    depends_on: [second]
+  third:
+    build:
+      context: .
+      recipe: Singularity.third
+

--- a/scompose/tests/test_depends_on.py
+++ b/scompose/tests/test_depends_on.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+
+# Copyright (C) 2019-2020 Vanessa Sochat.
+
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+# with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from scompose.project import Project
+from scompose.utils import run_command
+from time import sleep
+import shutil
+import pytest
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+
+def test_depends(tmp_path):
+
+    depends_on = os.path.join(here, "configs", "depends_on")
+    for filename in os.listdir(depends_on):
+        source = os.path.join(depends_on, filename)
+        dest = os.path.join(tmp_path, filename)
+        print("Copying %s to %s" % (filename, dest))
+        shutil.copyfile(source, dest)
+
+    # Test the simple apache example
+    os.chdir(tmp_path)
+
+    # Check for required files
+    assert "singularity-compose.yml" in os.listdir()
+
+    print("Creating project...")
+
+    # Loading project validates config
+    project = Project()
+
+    print("Testing build")
+    project.build()
+
+    for image in ["first.sif", "second.sif", "third.sif"]:
+        assert image in os.listdir(tmp_path)
+
+    print("Testing view config")
+    project.view_config()
+
+    print("Testing up")
+    project.up()
+
+    print("Waiting for instances to start")
+    sleep(10)
+
+    print("Bringing down")
+    project.down()

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.17"
+__version__ = "0.0.18"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "singularity-compose"


### PR DESCRIPTION
This pull request includes #31, and also starts to add a test for it. @pierlauro - please test this out locally because I haven't finished it yet and I have questions:

```
pytest --verbose -s scompose/tests/test_depends_on.py
```
I've created a setup for the test we need for depends_on, this is kept in tests/configs/depends_on, and copied to a temporary directory to run. Take a look at the singularity-compose.yml and let me know if this is what you had in mind - should this recipe trigger an exception for the dependency or not (it currently does). Once we've discussed this, I can either:

 - expect the error and catch it
 - fix the recipe so it doesn't error

And then print out the startscript echos somewhere so that we can verify the order of starting up. Let me know when you've had a chance to take a look, and with your feedback I can work on one of the next steps listed above!