### PR TITLE
singularity-compsose down timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - singularity-compose down supporting timeout (0.0.20)
  - command, ability to associate arguments to the instance's startscript (0.0.19)
  - depends\_on, check circular dependencies at startup and shutdown in reverse order (0.0.18)
  - resolv.conf, etc.hosts generated if needed, network disabled non-sudo users (0.0.17)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -165,6 +165,13 @@ To stop a custom set, just specify them:
 $ singularity-compose down nginx
 ```
 
+It is also possible to specify a timeout (as for singularity instance stop)
+in order to kill instances after the specified number of seconds:
+
+```bash
+singularity-compose down -t 100
+```
+
 ## Logs
 
 You can of course view logs for all instances, or just specific named ones:

--- a/scompose/client/__init__.py
+++ b/scompose/client/__init__.py
@@ -137,6 +137,15 @@ def get_parser():
 
     down = subparsers.add_parser("down", help="stop instances")
 
+    down.add_argument(
+        "--timeout",
+        "-t",
+        dest="timeout",
+        type=int,
+        help="force kill non stopped instances after specified seconds",
+        default=None,
+    )
+
     execute = subparsers.add_parser("exec", help="execute a command to an instance")
 
     run = subparsers.add_parser("run", help="run an instance runscript.")

--- a/scompose/client/down.py
+++ b/scompose/client/down.py
@@ -21,4 +21,4 @@ def main(args, parser, extra):
     )
 
     # Create instances, and if none specified, create all
-    project.down(args.names)
+    project.down(args.names, args.timeout)

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -353,13 +353,13 @@ class Instance(object):
                 self.instance = instance
                 break
 
-    def stop(self):
+    def stop(self, timeout=None):
         """delete the instance, if it exists. Singularity doesn't have delete
            or remove commands, everyting is a stop.
         """
         if self.instance:
             bot.info("Stopping %s" % self)
-            self.instance.stop(sudo=self.sudo)
+            self.instance.stop(sudo=self.sudo, timeout=timeout)
             self.instance = None
 
     # Networking

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -358,7 +358,7 @@ class Project(object):
 
     # Down
 
-    def down(self, names=None):
+    def down(self, names=None, timeout=None):
         """stop one or more instances. If no names are provided, bring them
            all down.
 
@@ -373,7 +373,7 @@ class Project(object):
             names.reverse()
 
         for instance in self.iter_instances(names):
-            instance.stop()
+            instance.stop(timeout=timeout)
 
     # Create
 

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.19"
+__version__ = "0.0.20"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "singularity-compose"

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -22,7 +22,7 @@ LICENSE = "LICENSE"
 
 
 INSTALL_REQUIRES = (
-    ("spython", {"min_version": "0.0.69"}),
+    ("spython", {"min_version": "0.0.77"}),
     ("pyaml", {"min_version": "5.1.1"}),
 )
 


### PR DESCRIPTION
Following the [recent change](https://github.com/singularityhub/singularity-cli/pull/150) in singularity-cli, this PR is simply adding the timeout option to `singularity-compose down`.

Manually tested that the call to `singularity-instance stop` is effectively receiving the timeout (not instrumenting any automated test for the same reasons explained in the overmentioned PR).