### PR TITLE
removed check for sudo when adding network flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - removed check for sudo when adding network flags (0.0.21)
  - singularity-compose down supporting timeout (0.0.20)
  - command, ability to associate arguments to the instance's startscript (0.0.19)
  - depends\_on, check circular dependencies at startup and shutdown in reverse order (0.0.18)

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -498,12 +498,11 @@ class Instance(object):
             # Volumes
             options += self._get_bind_commands()
 
-            if sudo:
-                # Ports
-                options += self._get_network_commands(ip_address)
+            # Ports
+            options += self._get_network_commands(ip_address)
 
-                # Hostname
-                options += ["--hostname", self.name]
+            # Hostname
+            options += ["--hostname", self.name]
 
             # Writable Temporary Directory
             if writable_tmpfs:

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "singularity-compose"


### PR DESCRIPTION
Small fix so that singularity-compose will add the ``--net`` flags when starting instances.

This just removes the check for sudo when Instance.create attempts to add the network flags.