### PR TITLE
Add configuration step required for recent versions of singularity

### DIFF
--- a/docs/spec/spec-2.0.md
+++ b/docs/spec/spec-2.0.md
@@ -113,7 +113,7 @@ The example below will run a container that exposes the port `5432` to the host.
       - 5432:5432
 ```
 
-**Obs.:** In recent versions of the Singularity CLI, there is the need for tweaking the 
+**Observation:** In recent versions of the Singularity CLI, there is the need for tweaking the 
 `/etc/singularity/singularity.conf` to allow `fakeroot` to bind to ports otherwise 
 an error will be thrown at container execution similar to this:
 

--- a/docs/spec/spec-2.0.md
+++ b/docs/spec/spec-2.0.md
@@ -113,6 +113,22 @@ The example below will run a container that exposes the port `5432` to the host.
       - 5432:5432
 ```
 
+**Obs.:** In recent versions of the Singularity CLI, there is the need for tweaking the 
+`/etc/singularity/singularity.conf` to allow `fakeroot` to bind to ports otherwise 
+an error will be thrown at container execution similar to this:
+
+```
+INFO:    Converting SIF file to temporary sandbox...
+ERROR:   Network fakeroot is not permitted for unprivileged users.
+INFO:    Cleaning up image...
+```
+
+To allow fakeroot to bind ports without sudo you need to execute this:
+
+```
+echo "allow net networks = bridge, fakeroot" >> /etc/singularity/singularity.conf
+```
+
 ## Start Group
 
 Startscript options generally include those for networking, and any other flags


### PR DESCRIPTION
I noticed that from Singularity >= 3.8.0 an additional step is required to make use of the `network -> allocate_ip` feature we added a couple of day ago.

This PR adds to the docs a reference to what the user must do in order to get it working (and avoid losing a few hours troubleshooting this like me 😓 )

**References:**

The 'culprit' is this if statement: 

https://github.com/hpcng/singularity/blob/release-3.8/internal/pkg/runtime/engine/singularity/container_linux.go#L2265-L2272

The solution is in this config file directive:

https://github.com/hpcng/singularity/blame/2c947291855a0374961774eeaa130815f6176cd4/pkg/util/singularityconf/config.go#L57 