### PR TITLE
Add network->enable feature to compose file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - add network->enable option on composer file (0.1.11)
  - add network->allocate_ip option on composer file (0.1.10)
  - version 2.0 of the spec with added fakeroot network, start, exec, and run options (0.1.0)
    - stop option added (equivalent functionality to down)   

--- a/docs/spec/spec-2.0.md
+++ b/docs/spec/spec-2.0.md
@@ -133,7 +133,7 @@ echo "allow net networks = bridge, fakeroot" >> /etc/singularity/singularity.con
 
 ### Enable/Disable Network
 
-By default `singularity-compose` will always append `--net` to command to be executed which in
+By default `singularity-compose` will always append `--net` to command to be executed in which it
 will prompt for either having `--network=none` or `--fakeroot` added.
 
 Depending on your environment's configuration and isolation requirements you may want to be able

--- a/docs/spec/spec-2.0.md
+++ b/docs/spec/spec-2.0.md
@@ -96,6 +96,8 @@ as a network (start) option (you might still be able to use it as a build option
 
 ## Network Group
 
+### Allocate IP Address
+
 By default `singularity-compose` will allocate an IP address for every instance in 
 the listed yaml file. Binding an IP address to a process requires `sudo` so in certain
 scenarios in which access to a privileged user isn't an option, you might want to tell
@@ -107,7 +109,7 @@ The example below will run a container that exposes the port `5432` to the host.
 ```yaml
   instance1:
     ...
-    network:
+    network:      
       allocate_ip: true | false
     ports:
       - 5432:5432
@@ -128,6 +130,25 @@ To allow fakeroot to bind ports without sudo you need to execute this:
 ```
 echo "allow net networks = bridge, fakeroot" >> /etc/singularity/singularity.conf
 ```
+
+### Enable/Disable Network
+
+By default `singularity-compose` will always append `--net` to command to be executed which in
+will prompt for either having `--network=none` or `--fakeroot` added.
+
+Depending on your environment's configuration and isolation requirements you may want to be able
+to instruct `singularity-compose` not to append `--net` or any network-related params to the command
+sent to singularity CLI.
+
+The example below will disable the network features:
+
+```yaml
+  instance1:
+    ...
+    network:      
+      enable: true | false
+```
+
 
 ## Start Group
 

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -148,13 +148,9 @@ class Instance(object):
         """set network from the recipe to be used"""
         self.network = params.get("network", {})
 
-        # if not specified, set the default value for allocate_ip property
-        if "allocate_ip" not in self.network:
-            self.network["allocate_ip"] = True
-
-        # if not specified, set the default value for enable property
-        if "enable" not in self.network:
-            self.network["enable"] = True
+        # if not specified, set the default value for the property
+        for key in ["enable", "allocate_ip"]:
+            self.network[key] = self.network.get(key, True)
 
     def set_ports(self, params):
         """set ports from the recipe to be used"""

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -546,7 +546,7 @@ class Instance(object):
             options += self._get_bind_commands()
 
             # Network configuration + Ports
-            if self.network['enable']:
+            if self.network["enable"]:
                 options += self._get_network_commands(ip_address)
 
             # Hostname

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -152,6 +152,10 @@ class Instance(object):
         if "allocate_ip" not in self.network:
             self.network["allocate_ip"] = True
 
+        # if not specified, set the default value for enable property
+        if "enable" not in self.network:
+            self.network["enable"] = True
+
     def set_ports(self, params):
         """set ports from the recipe to be used"""
         self.ports = params.get("ports", [])
@@ -541,8 +545,9 @@ class Instance(object):
             # Volumes
             options += self._get_bind_commands()
 
-            # Ports
-            options += self._get_network_commands(ip_address)
+            # Network configuration + Ports
+            if self.network['enable']:
+                options += self._get_network_commands(ip_address)
 
             # Hostname
             options += ["--hostname", self.name]

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
By default singularity-compose will always append --net to command to be executed in which it will prompt for either having --network=none or --fakeroot added.

Depending on your environment's configuration and isolation requirements you may want to be able to instruct singularity-compose not to append --net or any network-related params to the command sent to singularity CLI.

The example below will disable the network features:

```
  instance1:
    ...
    network:      
      enable: true | false
```