### PR TITLE
Handle ~ expansion when specifying bind volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - bind volumes can handle tilde expansion (0.0.14)
  - fix module import used by check command (0.0.13)
  - adding jsonschema validation and check command (0.0.12)
    - implement configuration override feature

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -216,6 +216,7 @@ class Instance(object):
         binds = []
         for volume in self.volumes:
             src, dest = volume.split(":")
+            src = os.path.expanduser(src)
 
             # First try, assume file in root folder
             if not os.path.exists(os.path.abspath(src)):

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
Bind volumes didn't take into account situations in which they might be located in user's home directory. While in production clusters this isn't very common, for dev workstations this sometimes can be useful.

Config:

```yaml
version: '2.0'
instances:

  database:
    build:
      context: .
      recipe: ./recipes/postgres/main.def
      options:
        - fakeroot
    start:
      options:
        - containall
    network:
      enable: false
    volumes:
      - ./recipes/postgres/env.sh:/.singularity.d/env/env.sh
      - ./volumes/postgres/conf:/opt/bitnami/postgresql/conf
      - ./volumes/postgres/tmp:/opt/bitnami/postgresql/tmp
      - ~/postgres_data:/bitnami/postgresql
```

Before:

```shell
$ singularity-compose -f singularity-compose-local.yml up

Building database
singularity build --fakeroot /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/database.sif ./recipes/postgres/main.def
Creating database

ERROR bind source file ~/postgres_data does not exist

```

Now:

```shell
$ singularity-compose -f singularity-compose-local.yml --debug up

Creating database
DEBUG singularity instance start --bind /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/recipes/postgres/env.sh:/.singularity.d/env/env.sh --bind /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/volumes/postgres/conf:/opt/bitnami/postgresql/conf --bind /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/volumes/postgres/tmp:/opt/bitnami/postgresql/tmp --bind /home/almeidarodenaspm/postgres_data:/bitnami/postgresql --bind /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/resolv.conf:/etc/resolv.conf --bind /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/etc.hosts:/etc/hosts --hostname database --writable-tmpfs /home/almeidarodenaspm/workspace/prefect-monorepo/singularity/database.sif database 
postgresql 14:19:06.37 
postgresql 14:19:06.37 Welcome to the Bitnami postgresql container
.......

```