### PR TITLE
Fix bug causing start->options to be ignored when network was set to false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ test_scompose: &test_scompose
         pytest -sv scompose/tests/test_client.py
         pytest -sv scompose/tests/test_utils.py
         pytest -sv scompose/tests/test_command_args.py
+        pytest -sv scompose/tests/test_config.py
 
 install_dependencies: &install_dependencies
   name: Install Python dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
+ - fix a bug triggered when using startoptions in conjunction with network=false (0.0.15)
  - bind volumes can handle tilde expansion (0.0.14)
  - fix module import used by check command (0.0.13)
  - adding jsonschema validation and check command (0.0.12)

--- a/scompose/project/instance.py
+++ b/scompose/project/instance.py
@@ -193,7 +193,7 @@ class Instance(object):
         """take a list of ports, return the list of --network-args to
         ensure they are bound correctly.
         """
-        ports = self.start_opts + ["--net"]
+        ports = ["--net"]
 
         # Fakeroot means not needing sudo
         fakeroot = "--fakeroot" in self.start_opts or "-f" in self.start_opts
@@ -545,6 +545,9 @@ class Instance(object):
             # Network configuration + Ports
             if self.network["enable"]:
                 options += self._get_network_commands(ip_address)
+
+            # Start options
+            options += self.start_opts
 
             # Hostname
             options += ["--hostname", self.name]

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
When the network->enable toggle mechanism was implemented, I forgot to handle an edge case that I just realized today.

It causes some of the options on the `start->options` to be ignored when `network->enable == false` given the way that the function `_get_network_commands` used to work. This PR fixes this behaviour.

Example config:

```yaml
agent:
  build:
    context: .
    recipe: ./recipes/corecli/main.def
    options:
      - fakeroot
  start:
    options:
      - containall
  network:
    enable: false
  volumes:
    - ./volumes/corecli/logs:/app_logs
  depends_on:
    - apollo
 ```

Before:
```
$ singularity-compose -f singularity-compose-local.yml --debug up

Creating agent
DEBUG singularity instance start \
    --bind <redacted>/volumes/corecli/logs:/app_logs \
    --bind <redacted>/resolv.conf:/etc/resolv.conf \
    --bind <redacted>/etc.hosts:/etc/hosts \
    --hostname agent \
    --writable-tmpfs \
    <redacted>/agent.sif agent 
```

After:
```
$ singularity-compose -f singularity-compose-local.yml --debug up

Creating agent
DEBUG singularity instance start \
    --bind <redacted>/volumes/corecli/logs:/app_logs \
    --bind <redacted>/resolv.conf:/etc/resolv.conf \
    --bind <redacted>/etc.hosts:/etc/hosts \
    --containall
    --hostname agent \
    --writable-tmpfs \
    <redacted>/agent.sif agent 
```