### PR TITLE
fix singularity check command when schema validation fails

### DIFF
--- a/scompose/client/check.py
+++ b/scompose/client/check.py
@@ -25,10 +25,10 @@ def main(args, parser, extra):
 
     # validate compose files
     for f in args.file:
-        result = validate_config(f)
-        if not result and not args.preview:
+        valid = validate_config(f)
+        if valid and not args.preview:
             bot.info("%s is valid." % f)
-        elif result:
+        else:
             bot.exit("%s is not valid." % f)
 
     if args.preview:


### PR DESCRIPTION
fix singularity check command. If validation failed then an exception was being thrown instead of printing error message

Now it's working as expected:

```
ERROR /home/paulo/workspace/singularity-compose/singularity-compose-invalid.yml is not valid.

Process finished with exit code 1
```
