### PR TITLE
Fix check command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ and **Merged pull requests**. Critical items to know are:
 
 The versions coincide with releases on pypi.
 
-## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x)
- - fix a bug triggered when using startoptions in conjunction with network=false (0.0.15)
- - bind volumes can handle tilde expansion (0.0.14)
- - fix module import used by check command (0.0.13)
- - adding jsonschema validation and check command (0.0.12)
+## [0.1.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.1.x)
+ - fix check command validation (0.1.16)
+ - fix a bug triggered when using startoptions in conjunction with network=false (0.1.15)
+ - bind volumes can handle tilde expansion (0.1.14)
+ - fix module import used by check command (0.1.13)
+ - adding jsonschema validation and check command (0.1.12)
    - implement configuration override feature
    - implement `--preview` argument for the `check` command 
  - add network->enable option on composer file (0.1.11)
@@ -25,6 +26,8 @@ The versions coincide with releases on pypi.
  - version 2.0 of the spec with added fakeroot network, start, exec, and run options (0.1.0)
    - stop option added (equivalent functionality to down)   
    - spython version 0.1.0 with Singularity 3.x or greater required
+
+## [0.0.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.0.x) 
  - removed check for sudo when adding network flags (0.0.21)
  - singularity-compose down supporting timeout (0.0.20)
  - command, ability to associate arguments to the instance's startscript (0.0.19)

--- a/scompose/client/check.py
+++ b/scompose/client/check.py
@@ -25,10 +25,10 @@ def main(args, parser, extra):
 
     # validate compose files
     for f in args.file:
-        result = validate_config(f)
-        if not result and not args.preview:
+        valid = validate_config(f)
+        if valid and not args.preview:
             bot.info("%s is valid." % f)
-        elif result:
+        else:
             bot.exit("%s is not valid." % f)
 
     if args.preview:

--- a/scompose/client/check.py
+++ b/scompose/client/check.py
@@ -28,7 +28,7 @@ def main(args, parser, extra):
         valid = validate_config(f)
         if valid and not args.preview:
             bot.info("%s is valid." % f)
-        else:
+        elif not valid:
             bot.exit("%s is not valid." % f)
 
     if args.preview:

--- a/scompose/config/schema.py
+++ b/scompose/config/schema.py
@@ -11,6 +11,8 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
 import sys
 
+from jsonschema.exceptions import ValidationError
+
 from scompose.utils import read_yaml
 
 # We don't require jsonschema, so catch import error and alert user
@@ -25,8 +27,12 @@ def validate_config(filepath):
     """
     Validate a singularity-compose.yaml file.
     """
-    cfg = read_yaml(filepath, quiet=True)
-    return validate(cfg, compose_schema)
+    try:
+        cfg = read_yaml(filepath, quiet=True)
+        validate(cfg, compose_schema)
+        return True
+    except ValidationError:
+        return False
 
 
 ## Singularity Compose Schema

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
fix singularity check command. If validation failed then an exception was being thrown instead of printing error message

Now it's working as expected:

```
ERROR /home/paulo/workspace/singularity-compose/singularity-compose-invalid.yml is not valid.

Process finished with exit code 1
```

Sorry about the previous PR, I had switched to another branch I'm working on and got confused...