### PR TITLE
adding support for custom network args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.1.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.1.x)
+ - support for network args (0.1.19)
+ - allow for background run commands (run->background:true) 0.1.18
  - add support for instance replicas (0.1.17)
  - fix check command validation (0.1.16)
  - fix a bug triggered when using startoptions in conjunction with network=false (0.1.15)

--- a/docs/spec/spec-2.0.md
+++ b/docs/spec/spec-2.0.md
@@ -127,7 +127,7 @@ INFO:    Cleaning up image...
 
 To allow fakeroot to bind ports without sudo you need to execute this:
 
-```
+```bash
 echo "allow net networks = bridge, fakeroot" >> /etc/singularity/singularity.conf
 ```
 
@@ -149,6 +149,41 @@ The example below will disable the network features:
       enable: true | false
 ```
 
+### Custom Network
+
+As of version 0.1.19 we have support for custom network args, and a full example of using a custom network
+[here](https://github.com/singularityhub/singularity-compose-examples/tree/master/v2.0/custom-network). 
+To summarize, let's say you start with this configuration at `/usr/local/etc/singularity/network/50_static-redis.conflist`:
+
+```yaml
+version: "2.0"
+instances:
+  cg-cache:
+    name: redis
+    run:
+      background: true
+    build:
+      context: .
+      recipe: redis.def
+    start:
+      background: true
+      options:
+        - "env-file=./env-file.sh"
+      command: redis-server --bind 0.0.0.0 --requirepass ${REDIS_PASSWORD}
+    volumes:
+      - ./env-file.sh:/.singularity.d/env/env-file.sh
+    network:
+      enable: true
+      allocate_ip: true
+
+      # If network args are provided, --network none is not used
+      args:
+        - '"portmap=6379:6379/tcp"'
+      ports:
+        - 6379:6379
+```
+
+The addition is support for ``--network-args`` and the custom network (the portmap) that you've defined above.
 
 ## Start Group
 

--- a/scompose/client/__init__.py
+++ b/scompose/client/__init__.py
@@ -91,7 +91,7 @@ def get_parser():
     )
 
     # print version and exit
-    version = subparsers.add_parser("version", help="show software version")
+    subparsers.add_parser("version", help="show software version")
 
     # Build
 
@@ -112,8 +112,7 @@ def get_parser():
     )
 
     # Config
-
-    config = subparsers.add_parser("config", help="Validate and view the compose file")
+    subparsers.add_parser("config", help="Validate and view the compose file")
 
     # Create (assumes built already), Up (will also build, if able)
 
@@ -189,7 +188,7 @@ def get_parser():
         action="store_true",
     )
 
-    ps = subparsers.add_parser("ps", help="list instances")
+    subparsers.add_parser("ps", help="list instances")
 
     # Add list of names
     for sub in [build, create, down, logs, up, restart, stop]:

--- a/scompose/config/schema.py
+++ b/scompose/config/schema.py
@@ -8,7 +8,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-import os
 import sys
 
 from jsonschema.exceptions import ValidationError
@@ -57,6 +56,8 @@ instance_network = {
     "properties": {
         "allocate_ip": {"type": "boolean"},
         "enable": {"type": "boolean"},
+        # --network-args
+        "args": string_list,
     },
 }
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -61,7 +61,8 @@ class Project:
         return names
 
     def set_filename(self, filename):
-        """Set the filename to read the recipe from.
+        """
+        Set the filename to read the recipe from.
 
         If not provided, defaults to singularity-compose.yml. The working directory
         is set to be the directory name of the configuration file.
@@ -297,7 +298,8 @@ class Project:
         return bridge_address
 
     def create_hosts(self, lookup):
-        """create a hosts file to bind to all containers, where we define the
+        """
+        Create a hosts file to bind to all containers, where we define the
         correct hostnames to correspond with the ip addresses created.
         Note: This function is terrible. Singularity should easily expose
               these addresses. See issue here:
@@ -503,8 +505,7 @@ class Project:
         bridge: the bridge ip address to use for networking, and generating
                 addresses for the individual containers.
                 see /usr/local/etc/singularity/network/00_bridge.conflist
-        no_resolv: if True, don't create and bind a resolv.conf with Google
-                   nameservers.
+        no_resolv: if True, don't create and bind a resolv.conf.
         """
         # If no names provided, we create all
         names = names or self.get_instance_names()

--- a/scompose/tests/test_client.py
+++ b/scompose/tests/test_client.py
@@ -10,7 +10,6 @@ from scompose.project import Project
 from scompose.utils import run_command
 from time import sleep
 import requests
-import pytest
 import os
 
 

--- a/scompose/tests/test_command_args.py
+++ b/scompose/tests/test_command_args.py
@@ -8,10 +8,8 @@
 
 from scompose.logger import bot
 from scompose.project import Project
-from scompose.utils import run_command
 from time import sleep
 import shutil
-import pytest
 import os
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/scompose/tests/test_depends_on.py
+++ b/scompose/tests/test_depends_on.py
@@ -8,10 +8,8 @@
 
 from scompose.logger import bot
 from scompose.project import Project
-from scompose.utils import run_command
 from time import sleep
 import shutil
-import pytest
 import os
 
 here = os.path.dirname(os.path.abspath(__file__))

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.17"
+__version__ = "0.1.19"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
This will close #60 @scicco you can follow the example here: https://github.com/singularityhub/singularity-compose-examples/tree/master/v2.0/custom-network

I think part of the trouble was the entrypoint had an envar, evaluated from the host is not going to work, so I added a startscript instead.  So this PR is adding support for custom network args primarily.

Give that a shot, show me what doesn't work (and I'll fix it up) and we can go from there!


Signed-off-by: vsoch <vsoch@users.noreply.github.com>