### PR TITLE
Pass 'bridge' parameter down into relevant function when calling 'up'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pypi.
 
 ## [0.1.x](https://github.com/singularityhub/singularity-compose/tree/master) (0.1.x)
+ - fix 'bridge' option for 'up' command (0.1.18)
  - add support for instance replicas (0.1.17)
  - fix check command validation (0.1.16)
  - fix a bug triggered when using startoptions in conjunction with network=false (0.1.15)

--- a/scompose/__init__.py
+++ b/scompose/__init__.py
@@ -7,4 +7,5 @@ Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
 with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
+
 from .version import __version__

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -476,6 +476,7 @@ class Project:
             names,
             command="up",
             writable_tmpfs=writable_tmpfs,
+            bridge=bridge,
             no_resolv=no_resolv,
         )
 

--- a/scompose/project/project.py
+++ b/scompose/project/project.py
@@ -453,7 +453,6 @@ class Project:
     def create(
         self, names=None, writable_tmpfs=True, bridge="10.22.0.0/16", no_resolv=False
     ):
-
         """
         Call the create function, which defaults to the command instance.create()
         """
@@ -466,7 +465,6 @@ class Project:
         bridge="10.22.0.0/16",
         no_resolv=False,
     ):
-
         """
         Call the up function, instance.up().
 
@@ -488,7 +486,6 @@ class Project:
         bridge="10.22.0.0/16",
         no_resolv=False,
     ):
-
         """
         Create one or more instances.
 

--- a/scompose/version.py
+++ b/scompose/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.1.17"
+__version__ = "0.1.18"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "singularity-compose"


### PR DESCRIPTION
The 'bridge' parameter wasn't passed along, so `up` failed in environments where the singularity bridge wasn't the default `10.22.0.0/16`.

Just had to passed down into the `_create` function.